### PR TITLE
travis to py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
-  - "2.7"
+  - "3.4"
 install: python setup.py install
 script: nosetests


### PR DESCRIPTION
I have a ticket in with BITS to re-enable builds in Travis since they got turned off after herc got open sourced.