### PR TITLE
Added finalizer processes to upload stdout and stderr to gcs buckets

### DIFF
--- a/data/schemas/jobsubmit.json
+++ b/data/schemas/jobsubmit.json
@@ -27,6 +27,16 @@
             "type": "array",
             "items": { "$ref": "#/definitions/pathpair" }
         },
+        "stdout": {
+            "type": "string",
+            "pattern": "^gs://(.+)",
+            "default": ""
+        },
+        "stderr": {
+            "type": "string",
+            "pattern": "^gs://(.+)",
+            "default": ""
+        },
         "resources": {
             "type" : "object",
             "properties" : {

--- a/docs/API.md
+++ b/docs/API.md
@@ -117,7 +117,9 @@ Below is an example payload:
             "cloud" : "gs://baz",
             "local" : "/baz"
         }
-    ]
+    ],
+    "stdout" : "gs://stdout",
+    "stderr" : "gs://stderr"
 }
 ```
 
@@ -135,6 +137,9 @@ The list of Mesos resources to request for this task. `cpus`, `mem`, and `disk` 
 
 #####`outputs`
 A list of files to upload back to the cloud after the work is done. The value for `cloud` must be a `gs://` file path (`boss://` isn't supported for upload).
+
+#####`stdout` and `stderr`
+If these are specified, the stdout or stderr output from the `commandline` will be uploaded to the cloud at these `gs://` paths.
 
 ### Example
 
@@ -171,9 +176,9 @@ Query Aurora and return the status of the job id. Will return HTTP 404 if not fo
 
 Because Aurora's definition of "terminal states" doesn't preclude a job being rescheduled, Herc may return a different status that more accurately represents what's happening with the job. Here's what you need to know:
 
-* `FINISHED`, `FAILED`, `KILLED`, `MEM_EXCEEDED` and `DISK_EXCEEDED` are the only terminal states. Any other state is non-terminal. You will never see the Aurora state `LOST`; Herc turns it into either `RESCHEDULED` or `KILLED` (see below).
-* When this endpoint returns `FAILED`, the JSON payload *may* include additional fields with more information. You should check the existence, and then value of the `response` field:
-  * `"response" : "MEM_EXCEEDED"` and `"response" : "DISK_EXCEEDED"` indicate the job failed because it exceeded the amount of memory or disk it requested in its Resources struct. In this case the JSON payload will contain two additional fields, `requested` and `used`; the values of both are strings, e.g. `128MB` or `3145728BYTES`. An example of this is below.
+* `FINISHED`, `FAILED` and `KILLED` are the only terminal states. Any other state is non-terminal. You will never see the Aurora state `LOST`; Herc turns it into either `RESCHEDULED` or `KILLED` (see below).
+* When this endpoint returns `FAILED`, the JSON payload *may* include additional fields with more information. You should check the existence, and then value of the `reason` field:
+  * `"reason" : "MEM_EXCEEDED"` and `"response" : "DISK_EXCEEDED"` indicate the job failed because it exceeded the amount of memory or disk it requested in its Resources struct. In this case the JSON payload will contain two additional fields, `requested` and `used`; the values of both are strings, e.g. `128MB` or `3145728BYTES`. An example of this is below.
 * `RESCHEDULED` is a non-terminal state added by Herc that indicates Aurora is in the process of rescheduling a job. This can happen when a job gets lost, pre-empted by a higher priority job, or the node it was running on is put into maintenance.
 * `KILLED` exclusively means "killed on request by a user or admin". It will be returned even if the job completes, fails, or gets lost before or during the execution of the kill request.
 

--- a/herc/backends/auroracli.py
+++ b/herc/backends/auroracli.py
@@ -76,8 +76,22 @@ class AuroraCLI(object):
                     'cmd': localize_cmd + ' "' + path['local'] + '" "' + path['cloud'] + '"'}
                    for (idx, path) in enumerate(jobrq['outputs'])]
 
-        # list of processes: download, run the commandline, upload
+        # list of processes: download inputs, run the commandline, upload outputs
         jr['processes'] = downloads + [{'name': jobid + '_ps', 'cmd': jobrq['commandline']}] + uploads
+
+        #finalizing processes to localize stdout and stderr up to gcs
+        #these are guaranteed to run even if the task fails because one of the other processes fail.
+        jr['finalizers'] = []
+        if jobrq['stdout'] != "":
+            jr['finalizers'].append({
+                'name' : "__locup_stdout",
+                'cmd' : localize_cmd + ' ".logs/' + jobid + '_ps/0/stdout" "' + jobrq['stdout'] + '"'
+            })
+        if jobrq['stderr'] != "":
+            jr['finalizers'].append({
+                'name' : "__locup_stderr",
+                'cmd' : localize_cmd + ' ".logs/' + jobid + '_ps/0/stderr" "' + jobrq['stderr'] + '"'
+            })
 
         # Currently all we need is one task, made of the list of download + run + upload processes.
         # We don't (yet?) need to do anything clever with Tasks.concat() or combine(), and the template doesn't support it.
@@ -85,7 +99,7 @@ class AuroraCLI(object):
         # combine(), that should be the final task in this list.
         jr['tasks'] = [{'name': jobid + '_task',
                         'type': 'SequentialTask',
-                        'processes': [p['name'] for p in jr['processes']],
+                        'processes': [p['name'] for p in jr['processes']] + [p['name'] for p in jr['finalizers']],
                         'cpus': jobrq['resources']['cpus'],
                         'mem': jobrq['resources']['mem'],
                         'memunit': jobrq['resources']['memunit'],

--- a/herc/backends/auroracli.py
+++ b/herc/backends/auroracli.py
@@ -98,8 +98,8 @@ class AuroraCLI(object):
         # The last task in this list will be used as the task to run on the job, so if we ever do use Tasks.concat() or
         # combine(), that should be the final task in this list.
         jr['tasks'] = [{'name': jobid + '_task',
-                        'type': 'SequentialTask',
                         'processes': [p['name'] for p in jr['processes']] + [p['name'] for p in jr['finalizers']],
+                        'ordering': [p['name'] for p in jr['processes']],
                         'cpus': jobrq['resources']['cpus'],
                         'mem': jobrq['resources']['mem'],
                         'memunit': jobrq['resources']['memunit'],

--- a/jobdefs/jobtemplate.aurora
+++ b/jobdefs/jobtemplate.aurora
@@ -4,6 +4,10 @@ import os
 {{ ps.name }} = Process( name = '{{ ps.name }}', cmdline = '{{ ps.cmd }}' )
 {% endfor %}
 
+{% for ps in finalizers %}
+{{ ps.name }} = Process( name = '{{ ps.name }}', cmdline = '{{ ps.cmd }}', final=True )
+{% endfor %}
+
 {% for task in tasks %}
 {{ task.name }} = {{ task.type }}(
     name = '{{ task.name }}',

--- a/jobdefs/jobtemplate.aurora
+++ b/jobdefs/jobtemplate.aurora
@@ -9,9 +9,10 @@ import os
 {% endfor %}
 
 {% for task in tasks %}
-{{ task.name }} = {{ task.type }}(
+{{ task.name }} = Task(
     name = '{{ task.name }}',
     processes = [ {{ task.processes|join(', ') }} ],
+    constraints = order( {{ task.ordering|join(', ') }} ),
     resources = Resources(  cpu = {{ task.cpus }},
                             ram = {{ task.mem }}*{{ task.memunit }},
                             disk = {{ task.disk }}*{{ task.diskunit }} )

--- a/tests/data/default_submit.json
+++ b/tests/data/default_submit.json
@@ -18,8 +18,8 @@
         "disk" : 1,
         "diskunit" : "MB"
     },
-    "stdout" : "gs://stdout",
-    "stderr" : "gs://stderr",
+    "stdout" : "",
+    "stderr" : "",
     "outputs" : [
         {
             "cloud" : "gs://baz",

--- a/tests/jinja_dicts.py
+++ b/tests/jinja_dicts.py
@@ -5,9 +5,13 @@ full_submit = {
 		{ 'name' : "TESTJOB_ps", 'cmd' : 'echo Hello herc! > /baz' },
 		{ 'name' : "locup_0", 'cmd' : 'localizer "/baz" "gs://baz"' }
 	],
+    'finalizers' : [
+        { 'name' : "__locup_stdout", 'cmd' : 'localizer ".logs/TESTJOB_ps/0/stdout" "gs://stdout"' },
+        { 'name' : "__locup_stderr", 'cmd' : 'localizer ".logs/TESTJOB_ps/0/stderr" "gs://stderr"' }
+    ],
     'tasks' : [{    'name' : 'TESTJOB_task',
                     'type' : 'SequentialTask',
-                    'processes' : [ "locdown_0", "locdown_1", "TESTJOB_ps", "locup_0" ],
+                    'processes' : [ "locdown_0", "locdown_1", "TESTJOB_ps", "locup_0", "__locup_stdout", "__locup_stderr" ],
                     'cpus' : 1,
                     'mem'  : 16,
                     'memunit' : "MB",

--- a/tests/jinja_dicts.py
+++ b/tests/jinja_dicts.py
@@ -10,8 +10,8 @@ full_submit = {
         { 'name' : "__locup_stderr", 'cmd' : 'localizer ".logs/TESTJOB_ps/0/stderr" "gs://stderr"' }
     ],
     'tasks' : [{    'name' : 'TESTJOB_task',
-                    'type' : 'SequentialTask',
                     'processes' : [ "locdown_0", "locdown_1", "TESTJOB_ps", "locup_0", "__locup_stdout", "__locup_stderr" ],
+                    'ordering' : [ "locdown_0", "locdown_1", "TESTJOB_ps", "locup_0" ],
                     'cpus' : 1,
                     'mem'  : 16,
                     'memunit' : "MB",

--- a/tests/test_auroracli.py
+++ b/tests/test_auroracli.py
@@ -4,6 +4,7 @@ from herc.backends import AuroraCLI
 import json
 
 class TestAuroraCLI(TestCase):
+    maxDiff = None
     def test_build_jinjadict(self):
         """Test that we transform a JSON request into a Jinja template fill correctly."""
         with open('tests/data/full_submit.json', 'r', encoding="utf-8") as fullsub:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -22,7 +22,7 @@ class TestValidator(tornado.testing.AsyncTestCase):
 	def test_validate_partialrq(self):
 		"""Tests that a correct, partial submission request validates, and is returned with missing data supplied."""
 		partialrq = get_str('tests/data/partial_submit.json')
-		fullrq = get_str('tests/data/full_submit.json')
+		fullrq = get_str('tests/data/default_submit.json')
 
 		validated = yield jsonvalidate.validate( partialrq, "data/schemas/jobsubmit.json" )
 		self.assertEqual( validated, json.loads(fullrq), "json returned from jsonvalidate should have defaults filled in" )


### PR DESCRIPTION
I had to jiggle the tests a bit. `partial_submit.json` should look like `default_submit.json` after defaults have been filled. `full_submit.json` is now the "here's a submit request with everything filled in" file.