### PR TITLE
Added nose to main package's dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(name='herc',
           'jsonref',
           'pyhocon',
           'mock',
-          'arrow'
+          'arrow',
+          'nose'
       ],
       entry_points={'console_scripts': ['herc = herc.webservice:main']},
       zip_safe=False,


### PR DESCRIPTION
Otherwise (at least in the Broad environment), `which nose` returns the global nose, not the one installed in the venv. `python setup.py test` works fine, but this fixes `nosetests --exe` throwing a ton of ImportErrors.